### PR TITLE
Humblebundle.com: un-sticky sub-header

### DIFF
--- a/ultralist.txt
+++ b/ultralist.txt
@@ -4314,6 +4314,7 @@ humaninterest.com###masthead:style(position: absolute !important;)
 humaninterest.com##.flash:style(position: absolute !important;)
 humblebundle.com##.js-maintain-scrollbar-on-dropdown.s-fixed.js-sticky-navbar.sticky-navbar
 humblebundle.com##.js-navigation-container-v2.navigation-container-v2:style(position: relative !important;)
+humblebundle.com##.storefront.v2 .nav-container.store-wide:style(position: static !important;)
 hunker.com###site-header:style(position: absolute !important; opacity: 1 !important;)
 hunker.com##.jwplayer__container--sticky.jwplayer__container:style(position: static !important;)
 hunker.com##.sticky-header


### PR DESCRIPTION
As of Dec. 2018, this is the sub-header containing links to
"On Sale", "New Releases", etc, and links to wishlist & cart.

This is my first contribution to a blocklist, test welcome.
Also, I used `static` but I'm not sure it's the best choice
(`inherit`, `absolute` `unset` also work). Which one?

### Gif

![humblebundle-subheader-inherit](https://user-images.githubusercontent.com/522085/49444803-3e7be300-f79e-11e8-8ff0-914ebb4b4227.gif)
