### PR TITLE
github.com: un-sticky PR toolbar shadow

### DIFF
--- a/ultralist.txt
+++ b/ultralist.txt
@@ -3088,7 +3088,7 @@ gitbook.com##.sticky:style(position: relative !important;)
 github.com##.UnderlineNav.user-profile-nav.top-0.is-placeholder
 github.com##.dashboard-sidebar.top-0.px-3.px-md-4.px-lg-4.overflow-auto.is-placeholder
 github.com##.gh-header .sticky-content, .gh-header .gh-header-shadow.box-shadow, .is-stuck.gh-header-sticky.top-0.js-sticky-offset-scroll.js-sticky
-github.com##.is-stuck.js-sticky-offset-scroll.js-sticky.pr-toolbar, .user-profile-nav:style(position: relative !important;)
+github.com##.is-stuck.js-sticky-offset-scroll.js-sticky.pr-toolbar, .toolbar-shadow, .user-profile-nav:style(position: relative !important;)
 github.com##.is-stuck.js-toggler-target.js-user-profile-follow-button.js-sticky.top-0.btn-block.btn:style(position: static !important;)
 github.com##.is-stuck.pl-5.col-2.float-right.js-sticky.bg-white.js-profile-timeline-year-list.profile-timeline-year-list:style(position: absolute !important;)
 github.com##.js-user-profile-sticky-fields.js-sticky.py-3.vcard-names-container:style(margin-top: 0 !important; pointer-events: none !important; width: auto !important;)


### PR DESCRIPTION
![screenshot_githubcom-toolbarshadow_2018-12-18-13 30 39](https://user-images.githubusercontent.com/522085/50175066-df53bd80-02c9-11e9-946b-e43cdb5e3c3b.png)
