### PR TITLE
Youtube: Fix bad filter

### DIFF
--- a/filters/floating_filters.txt
+++ b/filters/floating_filters.txt
@@ -9173,7 +9173,7 @@ youtube.com###header.ytd-c4-tabbed-header-renderer:style(position: absolute !imp
 youtube.com###header:style(transform: none !important; margin-top: 0 !important;)
 youtube.com###masthead-container:style(position: absolute !important; transition: none !important; transform: none !important;)
 youtube.com###masthead-positioner, #yt-masthead-container:style(position: relative !important; top: 0 !important;)
-youtube.com###masthead-positioner-height-offset, .iv-branding.annotation-type-custom.annotation, .ytp-promotooltip-wrapper
+youtube.com###masthead-positioner-height-offset, #chips-wrapper > #right-arrow, .iv-branding.annotation-type-custom.annotation, .ytp-promotooltip-wrapper
 youtube.com###wrapper.app-header-layout > [slot="header"]:style(position: relative !important; left: 0 !important;)
 youtube.com##.appbar-guide-menu-layout, .gstl_50.sbdd_a, .js-yt-header.yt-header, ytd-mini-guide-renderer.ytd-app, app-drawer[opened=""][persistent=""], ytd-two-column-browse-results-renderer[page-subtype="history"] #secondary.ytd-two-column-browse-results-renderer:style(position: absolute !important;)
 youtube.com##.no-scroll #page-manager:style(margin-top: 0px !important)

--- a/filters/floating_filters.txt
+++ b/filters/floating_filters.txt
@@ -9173,7 +9173,7 @@ youtube.com###header.ytd-c4-tabbed-header-renderer:style(position: absolute !imp
 youtube.com###header:style(transform: none !important; margin-top: 0 !important;)
 youtube.com###masthead-container:style(position: absolute !important; transition: none !important; transform: none !important;)
 youtube.com###masthead-positioner, #yt-masthead-container:style(position: relative !important; top: 0 !important;)
-youtube.com###masthead-positioner-height-offset, #right-arrow, .iv-branding.annotation-type-custom.annotation, .ytp-promotooltip-wrapper
+youtube.com###masthead-positioner-height-offset, .iv-branding.annotation-type-custom.annotation, .ytp-promotooltip-wrapper
 youtube.com###wrapper.app-header-layout > [slot="header"]:style(position: relative !important; left: 0 !important;)
 youtube.com##.appbar-guide-menu-layout, .gstl_50.sbdd_a, .js-yt-header.yt-header, ytd-mini-guide-renderer.ytd-app, app-drawer[opened=""][persistent=""], ytd-two-column-browse-results-renderer[page-subtype="history"] #secondary.ytd-two-column-browse-results-renderer:style(position: absolute !important;)
 youtube.com##.no-scroll #page-manager:style(margin-top: 0px !important)


### PR DESCRIPTION
A filter for #right-arrow elements removes arrows everywhere, making it impossible to navigate horizontal lists:

![FakerClipPoker](https://user-images.githubusercontent.com/66701832/169660881-6ae8dc1d-34f3-48f5-be4d-7304e6120a24.png)

![HumpsCreepPelf](https://user-images.githubusercontent.com/66701832/169660883-aabc5313-f403-4233-a050-52b104678f4e.png)

It was introduced in #260 do hide a weird fading effect.