### PR TITLE
Enable syntax highlighting for AdBlock filter files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,3 +12,8 @@
 # Denote all files that are truly binary and should not be modified.
 *.png binary
 *.jpg binary
+
+# Override classification for *.txt files, so they are highlighted as adblock files.
+# By default, Adblock language doesn't show up in the repository's language statistics,
+# but adding "linguist-detectable" will resolve this.
+*.txt linguist-language=AdBlock linguist-detectable


### PR DESCRIPTION
GitHub has supported syntactic highlighting of adblock filter lists since September 2022. This PR will help you turn it on.

Further informations:
- Syntax highlighter repository: https://github.com/ameshkov/VscodeAdblockSyntax
- How Linguist works: https://github.com/github/linguist/blob/master/docs/how-linguist-works.md
- Linguist overrides: https://github.com/github/linguist/blob/master/docs/overrides.md
- Linguist commit: https://github.com/github/linguist/commit/e78ef71af3600f96b9a40a06511ebbe3797e7401