### PR TITLE
Update floating_filters.txt

### DIFF
--- a/filters/floating_filters.txt
+++ b/filters/floating_filters.txt
@@ -9915,7 +9915,6 @@ youtube.com###chips-wrapper:style(position: static !important;)
 youtube.com###contentContainer.app-drawer:style(padding-top: 120px !important; padding-bottom: 0 !important;)
 youtube.com###contentContainer.tp-yt-app-drawer[swipe-open].tp-yt-app-drawer::after, tp-yt-app-drawer:style(position: absolute !important;)
 youtube.com###header.ytd-c4-tabbed-header-renderer:style(position: absolute !important; left: 0 !important;)
-youtube.com###header:style(transform: none !important; margin-top: 0 !important;)
 youtube.com###masthead-container:style(position: absolute !important; transition: none !important; transform: none !important;)
 youtube.com###masthead-positioner, #yt-masthead-container:style(position: relative !important; top: 0 !important;)
 youtube.com###masthead-positioner-height-offset, #right-arrow, .iv-branding.annotation-type-custom.annotation, .ytp-promotooltip-wrapper


### PR DESCRIPTION
On youtube channel pages (e. g. `https://www.youtube.com/@standwithus/videos`), the channel's top bar stays pinned on the screen, eating up a lot of screen space. Normally, it gets shrunk just to a tab bar. The pull request fixes this bug.

### Screenshots of the bug

**Broken state (page slightly scrolled down)**
<img width="1591" alt="image" src="https://github.com/yourduskquibbles/webannoyances/assets/31369902/9bacadfd-9e12-453f-99f2-9fc7d119254c">


**Fixed state**
<img width="1680" alt="image" src="https://github.com/yourduskquibbles/webannoyances/assets/31369902/671d509d-7a75-49bc-8e47-e8b208aa2059">


